### PR TITLE
BINDER_EXTERNAL_URL environment variable set from JUPYTERHUB_EXTERNAL…

### DIFF
--- a/notebooks/discursis_workshop.ipynb
+++ b/notebooks/discursis_workshop.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "# In order for bokeh to work properly on Binder, we need to specify\n",
     "#   the URL it's running on\n",
-    "os.environ[\"BINDER_EXTERNAL_URL\"] = \"https://notebooks.gesis.org/\"\n",
+    "os.environ[\"BINDER_EXTERNAL_URL\"] = os.environ.get('JUPYTERHUB_EXTERNAL_URL', \"https://notebooks.gesis.org/\")\n",
     "# pandas: tools for data processing\n",
     "import pandas as pd\n",
     "\n",


### PR DESCRIPTION
The BINDER_EXTERNAL_URL environment variable is now set from the JUPYTERHUB_EXTERNAL_URL environment variable if it is set, otherwise it is set to the value "https://notebooks.gesis.org" (as it was previously). 
This will allow interactive plots to work when the notebook is run on the ATAP BinderHub, but will make no difference if run elsewhere and the JUPYTERHUB_EXTERNAL_URL environment variable  is not set.